### PR TITLE
 Talon Implementation for Saving Hints and Scripting Actions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 David Martinez Tejada
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ Download or clone the repo to your user talon folder:
 ```bash
 git clone https://github.com/david-tejada/rango-talon
 ```
+
+## Issues
+
+If you have any issue please open one in the main [Rango](https://github.com/david-tejada/rango) repository.

--- a/rango.py
+++ b/rango.py
@@ -89,7 +89,7 @@ def rango_hint(m) -> str:
     return "".join(m.letter_list)
 
 
-@mod.capture(rule="<user.letter>")
+@mod.capture(rule="<user.letter> (twice | second)")
 def rango_hint_double(m) -> str:
     return m.letter + m.letter
 

--- a/rango.py
+++ b/rango.py
@@ -328,7 +328,7 @@ class UserActions:
     def rango_disable_direct_clicking():
         ctx.tags = []
 
-    def rangoRunActionOnReference(command: str, reference: str):
+    def rango_run_action_on_reference(command: str, reference: str):
         actions.user.rango_command_without_target(
             "runActionOnReference", command, reference
         )

--- a/rango.py
+++ b/rango.py
@@ -262,7 +262,7 @@ class Actions:
     def rango_disable_direct_clicking():
         """Disables rango direct mode"""
 
-    def rangoRunActionOnReference(command: str, reference: str):
+    def rango_run_action_on_reference(command: str, reference: str):
         """Runs a Rango command on a mark"""
 
 

--- a/rango.py
+++ b/rango.py
@@ -236,7 +236,9 @@ class Actions:
         """Executes a Rango command"""
 
     def rango_command_without_target(
-        actionType: str, arg: Union[str, float, None] = None,  arg2: Union[str, None] = None
+        actionType: str,
+        arg: Union[str, float, None] = None,
+        arg2: Union[str, None] = None,
     ):
         """Executes a Rango command without a target"""
 
@@ -282,7 +284,9 @@ class UserActions:
         return send_request_and_wait_for_response(action)
 
     def rango_command_without_target(
-        actionType: str, arg: Union[str, float, None] = None, arg2: Union[str, None] = None
+        actionType: str,
+        arg: Union[str, float, None] = None,
+        arg2: Union[str, None] = None,
     ):
         action = {"type": actionType}
         if arg:
@@ -325,6 +329,6 @@ class UserActions:
         ctx.tags = []
 
     def rango_run_action_on_mark(command: str, mark: str):
-        # Even though we are acting upon a mark this isn't a hint so it  
+        # Even though we are acting upon a mark this isn't a hint so it
         # technically doesn't have a target
         actions.user.rango_command_without_target("rangoActionOnSavedID", command, mark)

--- a/rango.py
+++ b/rango.py
@@ -262,7 +262,7 @@ class Actions:
     def rango_disable_direct_clicking():
         """Disables rango direct mode"""
 
-    def rango_run_action_on_mark(command: str, mark: str):
+    def rangoRunActionOnReference(command: str, reference: str):
         """Runs a Rango command on a mark"""
 
 
@@ -328,7 +328,7 @@ class UserActions:
     def rango_disable_direct_clicking():
         ctx.tags = []
 
-    def rango_run_action_on_mark(command: str, mark: str):
-        # Even though we are acting upon a mark this isn't a hint so it
-        # technically doesn't have a target
-        actions.user.rango_command_without_target("rangoActionOnSavedID", command, mark)
+    def rangoRunActionOnReference(command: str, reference: str):
+        actions.user.rango_command_without_target(
+            "runActionOnReference", command, reference
+        )

--- a/rango.py
+++ b/rango.py
@@ -232,7 +232,7 @@ class Actions:
         """Executes a Rango command"""
 
     def rango_command_without_target(
-        actionType: str, arg: Union[str, float, None] = None
+        actionType: str, arg: Union[str, float, None] = None,  arg2: Union[str, None] = None
     ):
         """Executes a Rango command without a target"""
 
@@ -278,11 +278,13 @@ class UserActions:
         return send_request_and_wait_for_response(action)
 
     def rango_command_without_target(
-        actionType: str, arg: Union[str, float, None] = None
+        actionType: str, arg: Union[str, float, None] = None, arg2: Union[str, None] = None
     ):
         action = {"type": actionType}
         if arg:
             action["arg"] = arg
+        if arg2:
+            action["arg2"] = arg2
         return send_request_and_wait_for_response(action)
 
     def rango_try_to_focus_and_check_is_editable(target: Union[str, list[str]]):
@@ -319,4 +321,6 @@ class UserActions:
         ctx.tags = []
 
     def rango_run_action_on_mark(command: str, mark: str):
-        actions.user.rango_command_without_target("rangoActionOnSavedID", f'{command}%{mark}')
+        # Even though we are acting upon a mark this isn't a hint so it  
+        # technically doesn't have a target
+        actions.user.rango_command_without_target("rangoActionOnSavedID", command, mark)

--- a/rango.py
+++ b/rango.py
@@ -256,6 +256,9 @@ class Actions:
     def rango_disable_direct_clicking():
         """Disables rango direct mode"""
 
+    def rango_run_action_on_mark(command: str, mark: str):
+        """Runs a Rango command on a mark"""
+
 
 @ctx.action_class("user")
 class UserActions:
@@ -314,3 +317,6 @@ class UserActions:
 
     def rango_disable_direct_clicking():
         ctx.tags = []
+
+    def rango_run_action_on_mark(command: str, mark: str):
+        actions.user.rango_command_without_target("rangoActionOnSavedID", f'{command}%{mark}')

--- a/rango.talon
+++ b/rango.talon
@@ -234,10 +234,14 @@ rango settings: user.rango_command_without_target("openSettingsPage")
 # Pages
 rango open {user.rango_page}: user.rango_command_without_target("openPageInNewTab", rango_page)
 
-#  Hint/element references for scripting
+# Save hints for a given website as mark names used for scripting browser actions. 
+# The mark will refer to the same HTML element even if the letters in the hint change
 mark <user.rango_target> as <user.word>: user.rango_command_with_target("saveReference", rango_target, word)
 mark show: user.rango_command_without_target("showReferences")
 mark clear <user.word>: user.rango_command_without_target("removeReference", word)
+
+# Marks can be clicked, focused, or hovered by calling 
+# "user.rango_run_action_on_reference" in your scripts
 click mark <user.word>: user.rango_run_action_on_reference("clickElement", word)
 focus mark <user.word>: user.rango_run_action_on_reference("focusElement", word)
 hover mark <user.word>: user.rango_run_action_on_reference("hoverElement", word)

--- a/rango.talon
+++ b/rango.talon
@@ -235,11 +235,9 @@ rango settings: user.rango_command_without_target("openSettingsPage")
 rango open {user.rango_page}: user.rango_command_without_target("openPageInNewTab", rango_page)
 
 #  Hint/element references for scripting
-reference <user.rango_target> as <user.word>: 
-  user.rango_command_with_target("saveReference", rango_target, word)
-
-reference show: 
-  user.rango_command_without_target("showReferences")
-
-reference clear <user.word>: 
-  user.rango_command_without_target("removeReference", word)
+mark <user.rango_target> as <user.word>: user.rango_command_with_target("saveReference", rango_target, word)
+mark show: user.rango_command_without_target("showReferences")
+mark clear <user.word>: user.rango_command_without_target("removeReference", word)
+click mark <user.word>: user.rango_run_action_on_reference("clickElement", word)
+focus mark <user.word>: user.rango_run_action_on_reference("focusElement", word)
+hover mark <user.word>: user.rango_run_action_on_reference("hoverElement", word)

--- a/rango.talon
+++ b/rango.talon
@@ -220,7 +220,7 @@ rango open {user.rango_page}: user.rango_command_without_target("openPageInNewTa
 save <user.rango_target> as <user.word>: 
   user.rango_command_with_target("saveHintID", rango_target, word)
 
-show saved hints: 
+show saved marks: 
   user.rango_command_without_target("showSavedIDs")
 
 remove mark <user.word>: 

--- a/rango.talon
+++ b/rango.talon
@@ -223,9 +223,5 @@ save <user.rango_target> as <user.word>:
 show saved hints: 
   user.rango_command_without_target("showSavedIDs")
 
-# Sample API Demonstration
-# run hint script:
-#   user.rango_run_action_on_mark("clickElement", "home")
-#   print('done')
-#   sleep(5)
-#   user.rango_run_action_on_mark("clickElement", "country")
+remove mark <user.word>: 
+  user.rango_command_without_target("removeHintID", word)

--- a/rango.talon
+++ b/rango.talon
@@ -234,12 +234,12 @@ rango settings: user.rango_command_without_target("openSettingsPage")
 # Pages
 rango open {user.rango_page}: user.rango_command_without_target("openPageInNewTab", rango_page)
 
-#  Save a hint so it can be used for scripting
-save <user.rango_target> as <user.word>: 
-  user.rango_command_with_target("saveHintID", rango_target, word)
+#  Hint/element references for scripting
+reference <user.rango_target> as <user.word>: 
+  user.rango_command_with_target("saveReference", rango_target, word)
 
-show saved marks: 
-  user.rango_command_without_target("showSavedIDs")
+reference show: 
+  user.rango_command_without_target("showReferences")
 
-remove mark <user.word>: 
-  user.rango_command_without_target("removeHintID", word)
+reference clear <user.word>: 
+  user.rango_command_without_target("removeReference", word)

--- a/rango.talon
+++ b/rango.talon
@@ -234,14 +234,12 @@ rango settings: user.rango_command_without_target("openSettingsPage")
 # Pages
 rango open {user.rango_page}: user.rango_command_without_target("openPageInNewTab", rango_page)
 
-# Save hints for a given website as mark names used for scripting browser actions. 
-# The mark will refer to the same HTML element even if the letters in the hint change
+#  Hint/element references for scripting
 mark <user.rango_target> as <user.word>: user.rango_command_with_target("saveReference", rango_target, word)
 mark show: user.rango_command_without_target("showReferences")
 mark clear <user.word>: user.rango_command_without_target("removeReference", word)
 
-# Marks can be clicked, focused, or hovered by calling 
-# "user.rango_run_action_on_reference" in your scripts
+# Run actions on saved references
 click mark <user.word>: user.rango_run_action_on_reference("clickElement", word)
 focus mark <user.word>: user.rango_run_action_on_reference("focusElement", word)
 hover mark <user.word>: user.rango_run_action_on_reference("hoverElement", word)

--- a/rango.talon
+++ b/rango.talon
@@ -215,3 +215,17 @@ rango settings: user.rango_command_without_target("openSettingsPage")
 
 # Pages
 rango open {user.rango_page}: user.rango_command_without_target("openPageInNewTab", rango_page)
+
+#  Save a hint so it can be used for scripting
+save <user.rango_target> as <user.word>: 
+  user.rango_command_with_target("saveHintID", rango_target, word)
+
+show saved hints: 
+  user.rango_command_without_target("showSavedIDs")
+
+# Sample API Demonstration
+# run hint script:
+#   user.rango_run_action_on_mark("clickElement", "home")
+#   print('done')
+#   sleep(5)
+#   user.rango_run_action_on_mark("clickElement", "country")

--- a/rango_direct_clicking.talon
+++ b/rango_direct_clicking.talon
@@ -3,4 +3,4 @@ and tag: user.rango_direct_clicking
 -
 
 ^<user.rango_target>$: user.rango_command_with_target("directClickElement", rango_target)
-^<user.rango_hint_double> (twice | second)$: user.rango_command_with_target("directClickElement", rango_hint_double)
+^<user.rango_hint_double>$: user.rango_command_with_target("directClickElement", rango_hint_double)

--- a/rango_talon_helpers.talon
+++ b/rango_talon_helpers.talon
@@ -1,0 +1,5 @@
+tag: user.talon
+-
+click rango mark <user.word>: "user.rango_run_action_on_reference(\"clickElement\", {word})"
+focus rango mark <user.word>: "user.rango_run_action_on_reference(\"focusElement\", {word})"
+hover rango mark <user.word>: "user.rango_run_action_on_reference(\"hoverElement\", {word})"

--- a/rango_talon_helpers.talon
+++ b/rango_talon_helpers.talon
@@ -1,5 +1,6 @@
 tag: user.talon
 -
+# Helpers to make scripting using references easier
 click rango mark <user.word>: "user.rango_run_action_on_reference(\"clickElement\", {word})"
 focus rango mark <user.word>: "user.rango_run_action_on_reference(\"focusElement\", {word})"
 hover rango mark <user.word>: "user.rango_run_action_on_reference(\"hoverElement\", {word})"


### PR DESCRIPTION
This code implements functions for saving hints and scripting with them. It is relatively straightforward, but there is one new function to mention: `rango_run_action_on_mark`. This function was added because it can be confusing for users to use `rango_command_without_target` for scripting, as they have to pass in a saved mark name  and so it looks like in action with a target.

In TypeScript, `rango_command_without_target` only takes one argument in the request. To work around this limitation, I used a string with a delimiter in the middle. However, this approach is error-prone and not a good stylistic practice. I'm open to suggestions for a better solution 