### PR TITLE
Don't loop forever if clipboard contents are not JSON

### DIFF
--- a/src/command_server.py
+++ b/src/command_server.py
@@ -36,18 +36,15 @@ def read_json_response_with_timeout(timeout_seconds) -> Any:
         raw_text = clip.text()
         try:
             message = json.loads(raw_text)
+            if message["type"] == "response":
+                return message
         # We make sure the message is valid JSON. For example, if a click command
         # results in something being copied to the clipboard and we check the clipboard
         # before Rango has time to copy the response to the clipboard.
         except ValueError as error:
-            if initial_raw_text != raw_text:
-                continue
-            else:
+            if initial_raw_text == raw_text:
                 # Sanity check to make sure the initial request was valid JSON
                 raise ValueError("The request message wasn't valid JSON")
-
-        if message["type"] == "response":
-            break
 
         actions.sleep(sleep_time)
 

--- a/src/command_server.py
+++ b/src/command_server.py
@@ -58,8 +58,6 @@ def read_json_response_with_timeout(timeout_seconds) -> Any:
         # small sleeps due to clock slip
         sleep_time = max(min(sleep_time * 2, time_left), MINIMUM_SLEEP_TIME_SECONDS)
 
-    return message
-
 
 def send_request_and_wait(action: dict) -> Any:
     message = {"version": 1, "type": "request", "action": action}


### PR DESCRIPTION
If, after the response message has been copied to the clipboard, but before the response message has been read by the `read_json_response_with_timeout` function, the clipboard somehow gets overwritten with a non-JSON value,  the function will loop forever and Talon will get stuck ([full logs](https://gist.github.com/ethantkoenig/fc797820668b224b8e71c6c5a166586b)):

```
2024-03-03 17:57:50.714 WARNING [watchdog] "EngineProxy._redispatch" @68.0s (stalled)
2024-03-03 17:57:50.758 WARNING [watchdog] "SpeechSystem.engine_event" @68.0s
   25:            lib/python3.11/threading.py:995 * # cron thread
   24:            lib/python3.11/threading.py:1038* 
   23:            lib/python3.11/threading.py:975 * 
   22:                          talon/cron.py:156 | 
   21:                           talon/vad.py:23  | 
   20:                           talon/vad.py:129 | 
   19:       talon/scripting/speech_system.py:370 | 
   18:                   talon/engines/w2l.py:757 | 
   17:            talon/scripting/dispatch.py:134 | # 'phrase' main:EngineProxy._redispatch()
   16:       talon/scripting/speech_system.py:67  | 
   15:            talon/scripting/dispatch.py:134 | # 'phrase' main:SpeechSystem.engine_event()
   14:       talon/scripting/speech_system.py:487 | 
   13:            talon/scripting/executor.py:111 | 
   12:        talon/scripting/talon_script.py:707 | 
   11:        talon/scripting/talon_script.py:606 | 
   10:        talon/scripting/talon_script.py:308 | 
    9:             talon/scripting/actions.py:88  | # user.rango_command_with_target()
    8:        user/rango-talon/src/command.py:20  | return actions.user.rango_run_command(..
    7:             talon/scripting/actions.py:88  | # user.rango_run_command()
    6: user/rango-talon/src/command_server.py:144 | response = send_request_and_wait(action)
    5: user/rango-talon/src/command_server.py:73  | response = read_json_response_with_tim..
    4: user/rango-talon/src/command_server.py:38  | message = json.loads(raw_text)
    3:        lib/python3.11/json/__init__.py:346 | 
    2:         lib/python3.11/json/decoder.py:337 | 
    1:         lib/python3.11/json/decoder.py:355 | 
```