### PR TITLE
Automatically detect Safari v18 to use keypad

### DIFF
--- a/src/overrides/safari.py
+++ b/src/overrides/safari.py
@@ -1,6 +1,5 @@
 from talon import Context, actions
-from ..overrides import safari_version # only relative imports work
-
+from ..overrides import safari_version  # only relative imports work
 
 ctx = Context()
 ctx.matches = r"""
@@ -8,9 +7,11 @@ tag: browser
 app: safari
 """
 
+_SAFARI_VERSION = safari_version.get()
+_HOTKEY = "ctrl-shift-keypad_3" if _SAFARI_VERSION.startswith("18.") else "ctrl-shift-3"
+
+
 @ctx.action_class("user")
 class UserActions:
     def rango_type_hotkey():
-        version = safari_version.get()
-        key = "ctrl-shift-keypad_3" if version.startswith('18.') else "ctrl-shift-3"
-        actions.key(key)
+        actions.key(_HOTKEY)

--- a/src/overrides/safari.py
+++ b/src/overrides/safari.py
@@ -1,5 +1,5 @@
 from talon import Context, actions
-from .safari_version import get_safari_version  # only relative imports work
+from .safari_version import get_safari_version
 
 ctx = Context()
 ctx.matches = r"""

--- a/src/overrides/safari.py
+++ b/src/overrides/safari.py
@@ -1,5 +1,5 @@
 from talon import Context, actions
-from ..overrides import safari_version
+from ..overrides import safari_version # only relative imports work
 
 
 ctx = Context()

--- a/src/overrides/safari.py
+++ b/src/overrides/safari.py
@@ -1,5 +1,5 @@
 from talon import Context, actions
-from ..overrides import safari_version  # only relative imports work
+from .safari_version import get_safari_version  # only relative imports work
 
 ctx = Context()
 ctx.matches = r"""
@@ -7,11 +7,12 @@ tag: browser
 app: safari
 """
 
-_SAFARI_VERSION = safari_version.get()
-_HOTKEY = "ctrl-shift-keypad_3" if _SAFARI_VERSION.startswith("18.") else "ctrl-shift-3"
+_hotkey = (
+    "ctrl-shift-keypad_3" if get_safari_version().startswith("18.") else "ctrl-shift-3"
+)
 
 
 @ctx.action_class("user")
 class UserActions:
     def rango_type_hotkey():
-        actions.key(_HOTKEY)
+        actions.key(_hotkey)

--- a/src/overrides/safari.py
+++ b/src/overrides/safari.py
@@ -1,7 +1,5 @@
-import os
-import plistlib
-import subprocess
 from talon import Context, actions
+from ..overrides import safari_version
 
 
 ctx = Context()
@@ -10,29 +8,9 @@ tag: browser
 app: safari
 """
 
-safari_version = ''
-
-def get_safari_version() -> str:
-    global safari_version
-    try:
-        if safari_version != '':
-            return safari_version
-        
-        paths = subprocess.getoutput(f'mdfind "kMDItemCFBundleIdentifier == com.apple.Safari"').splitlines()
-        for path in paths:
-            with open(os.path.join(path, "Contents/Info.plist"), "rb") as f:
-                plist = plistlib.load(f)
-                safari_version = plist['CFBundleShortVersionString']
-    except Exception as e:
-        safari_version = 'unknown'
-        print('Exception retrieving safari version:', e.__class__, e)
-    finally:
-        return safari_version
-
-
 @ctx.action_class("user")
 class UserActions:
     def rango_type_hotkey():
-        version = get_safari_version()
+        version = safari_version.get()
         key = "ctrl-shift-keypad_3" if version.startswith('18.') else "ctrl-shift-3"
         actions.key(key)

--- a/src/overrides/safari.py
+++ b/src/overrides/safari.py
@@ -1,4 +1,8 @@
+import os
+import plistlib
+import subprocess
 from talon import Context, actions
+
 
 ctx = Context()
 ctx.matches = r"""
@@ -6,7 +10,29 @@ tag: browser
 app: safari
 """
 
+safari_version = ''
+
+def get_safari_version() -> str:
+    global safari_version
+    try:
+        if safari_version != '':
+            return safari_version
+        
+        paths = subprocess.getoutput(f'mdfind "kMDItemCFBundleIdentifier == com.apple.Safari"').splitlines()
+        for path in paths:
+            with open(os.path.join(path, "Contents/Info.plist"), "rb") as f:
+                plist = plistlib.load(f)
+                safari_version = plist['CFBundleShortVersionString']
+    except Exception as e:
+        safari_version = 'unknown'
+        print('Exception retrieving safari version:', e.__class__, e)
+    finally:
+        return safari_version
+
+
 @ctx.action_class("user")
 class UserActions:
     def rango_type_hotkey():
-        actions.key("ctrl-shift-3")
+        version = get_safari_version()
+        key = "ctrl-shift-keypad_3" if version.startswith('18.') else "ctrl-shift-3"
+        actions.key(key)

--- a/src/overrides/safari_version.py
+++ b/src/overrides/safari_version.py
@@ -2,23 +2,15 @@ import os
 import subprocess
 import plistlib
 
-
-_safari_version = ""
 _SAFARI_BUNDLE = "com.apple.Safari"
 
 
-def get() -> str:
-    global _safari_version
-    if _safari_version != "":
-        return _safari_version
-
+def get_safari_version() -> str:
     try:
-        _safari_version = _get_app_version_by_bundle_id(_SAFARI_BUNDLE)
+        return _get_app_version_by_bundle_id(_SAFARI_BUNDLE)
     except Exception as e:
-        _safari_version = "unknown"
         print("Exception retrieving safari version:", e.__class__, e)
-    finally:
-        return _safari_version
+        return "unknown"
 
 
 def _get_app_version_by_bundle_id(id: str) -> str:

--- a/src/overrides/safari_version.py
+++ b/src/overrides/safari_version.py
@@ -1,25 +1,44 @@
 import os
 import subprocess
+import plistlib
 
 
-_safari_version = ''
+_safari_version = ""
+_SAFARI_BUNDLE = "com.apple.Safari"
+
 
 def get() -> str:
     global _safari_version
+    if _safari_version != "":
+        return _safari_version
+
     try:
-        if _safari_version != '':
-            return _safari_version
-        
-        import plistlib 
-        # Not sure how Python handles this cross-platform: 
-        # imported inside try-catch to avoid breaking other platforms
-        paths = subprocess.getoutput(f'mdfind "kMDItemCFBundleIdentifier == com.apple.Safari"').splitlines()
-        for path in paths:
-            with open(os.path.join(path, "Contents/Info.plist"), "rb") as f:
-                plist = plistlib.load(f)
-                _safari_version = plist['CFBundleShortVersionString']
+        _safari_version = _get_app_version_by_bundle_id(_SAFARI_BUNDLE)
     except Exception as e:
-        _safari_version = 'unknown'
-        print('Exception retrieving safari version:', e.__class__, e)
+        _safari_version = "unknown"
+        print("Exception retrieving safari version:", e.__class__, e)
     finally:
         return _safari_version
+
+
+def _get_app_version_by_bundle_id(id: str) -> str:
+    """
+    Returns the semantic version of the first application matching the supplied bundle id.
+
+    See: https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring
+    """
+    for path in _find_app_paths_by_bundle_id(id):
+        return _read_version_from_plist(path)
+    return "unknown"
+
+
+def _find_app_paths_by_bundle_id(id: str) -> list[str]:
+    """Returns a list of paths to applications matching the supplied bundle id."""
+    _subprocess_command = f'mdfind "kMDItemCFBundleIdentifier == {id}"'
+    return subprocess.getoutput(_subprocess_command).splitlines()
+
+
+def _read_version_from_plist(path: str) -> str:
+    """Returns the semantic version string of the application at the supplied path."""
+    with open(os.path.join(path, "Contents/Info.plist"), "rb") as f:
+        return plistlib.load(f)["CFBundleShortVersionString"]

--- a/src/overrides/safari_version.py
+++ b/src/overrides/safari_version.py
@@ -1,0 +1,25 @@
+import os
+import subprocess
+
+
+_safari_version = ''
+
+def get() -> str:
+    global _safari_version
+    try:
+        if _safari_version != '':
+            return _safari_version
+        
+        import plistlib 
+        # Not sure how Python handles this cross-platform: 
+        # imported inside try-catch to avoid breaking other platforms
+        paths = subprocess.getoutput(f'mdfind "kMDItemCFBundleIdentifier == com.apple.Safari"').splitlines()
+        for path in paths:
+            with open(os.path.join(path, "Contents/Info.plist"), "rb") as f:
+                plist = plistlib.load(f)
+                _safari_version = plist['CFBundleShortVersionString']
+    except Exception as e:
+        _safari_version = 'unknown'
+        print('Exception retrieving safari version:', e.__class__, e)
+    finally:
+        return _safari_version


### PR DESCRIPTION
# Motivation

Safari v18 broke the use of the `ctrl-shift-3` hotkey used to click targets. Ideally, Rango would automatically detect the correct hotkey combination for a particular version of Safari.

Fixes: https://github.com/david-tejada/rango/issues/309

# Solution

* Introduces a `safari_version.get` function. 
* This function is memoized since it involves subprocess and file system calls. 
* If an exception occurs, this function returns and memoizes `unknown` as the Safari version
* It falls back to the old configuration for any version other than v18. If we are confident this key combination will continue to be required in subsequent Safari versions, this function could be improved to return a semantic version tuple, allowing fine-grained version-dependent behaviour.

# Testing

I've only been able to test this on:

* macOS 15 with Safari 18
* macOS 15 with Chrome 129

I tested the exception behavior by adding a `print(x)` statement in the try block and observing:

* The exception set the `_safari_version` to `unknown` as expected
* Subsequent rango actions did not hit the exception block as expected
* Behavior fell back to the default `ctrl-shift-3` key as expected. However, this was observed by printing `key` to the console. Since I only have Safari 18, the command server raised the `Timed out waiting for response` exception I was experiencing before the fix. 

## Caveats

It has been a few years since I wrote Python code 😅 let me know if anything isn't idiomatic.